### PR TITLE
Switch AI provider from Gemini to GPT-3.5 Turbo

### DIFF
--- a/app/configs/ai-config.json
+++ b/app/configs/ai-config.json
@@ -1,5 +1,5 @@
 {
-    "provider": "Google",
-    "model_name": "gemini-1.5-pro",
+    "provider": "OpenAI",
+    "model_name": "gpt-3.5-turbo",
     "playstyle": "neutral"
 }


### PR DESCRIPTION
This PR switches the AI provider from Gemini to GPT-3.5 Turbo.