### PR TITLE
Refresh model registry (Claude 5 family) and rewrite the README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -252,7 +252,9 @@ The arena benchmarks LLMs against each other on a real rules engine, **PokerKit*
   resolves `id → AIConfig` (`toAIConfig`) and throws `unknown model id: X` on an
   unregistered id. **`scripts/update-models.ts` is the sole writer** (`npm run
   update-models`): fetches each provider's live model list, keeps an allowlisted
-  family (`gpt-5.x*`, `gemini-3*` text-gen, `claude-*-4*`), and merges
+  family (`gpt-5.x*`/`o3`, `gemini-3*` text-gen, and `claude-<tier>-<version>` —
+  tier-keyed and version-agnostic, so a new Claude generation is picked up
+  without a regex bump; the legacy `claude-3-opus-*` naming stays excluded), and merges
   non-clobbering — preserving ids/addedAt/deprecated/costs/reasoning, collapsing
   dated snapshots to a family id, deprecating (never deleting) vanished models,
   and writing deterministically (sorted, fixed key order) so reruns are zero-diff.
@@ -265,10 +267,14 @@ The arena benchmarks LLMs against each other on a real rules engine, **PokerKit*
   `reasoning_effort` (low/medium/high); **Claude** sets adaptive thinking
   (`thinking:{type:"adaptive"}` + `output_config.effort`) with a bigger token
   budget and a defensive retry-without-thinking on the 400 you get from a model
-  that doesn't support it (so only adaptive-capable Claudes — Opus 4.6+/Sonnet
-  4.6 — are non-`none` in the registry; Haiku 4.5 / Sonnet 4.5 / Opus 4.5 are
-  `none`); **Gemini** is a no-op (pinned SDK 0.14.1 has no `thinkingConfig`; the
-  models reason automatically).
+  that doesn't support it (so only adaptive-capable Claudes — the Claude 5 family
+  (Opus 5 / Sonnet 5 / Fable 5) and Opus 4.6+/Sonnet 4.6 — are non-`none` in the
+  registry; Haiku 4.5 / Sonnet 4.5 / Opus 4.5 are `none`); **Gemini** is a no-op
+  (pinned SDK 0.14.1 has no `thinkingConfig`; the models reason automatically).
+  **Don't register a Claude 5 model as `none`**: on that path the service omits
+  `thinking` entirely, but Opus 5 and Fable 5 think by default, and the smaller
+  non-reasoning `max_tokens` (4096) then caps thinking + text together and can
+  truncate the response before the `Final Answer:` line.
 - **Python venv setup** (one-time):
   ```sh
   py -m venv engine-py/.venv

--- a/README.md
+++ b/README.md
@@ -9,10 +9,11 @@
     <li>
       <a href="#about-the-project">About The Project</a>
        <ul>
-        <li><a href="#why-chatgpt-over-gto">Why ChatGPT over GTO?</a></li>
+        <li><a href="#why-chatgpt-or-other-llms-over-gto">Why ChatGPT over GTO?</a></li>
        </ul>
       <ul>
         <li><a href="#built-with">Built With</a></li>
+        <li><a href="#project-layout">Project Layout</a></li>
       </ul>
     </li>
     <li>
@@ -23,9 +24,21 @@
       </ul>
     </li>
     <li>
+      <a href="#the-arena">The Arena</a>
+      <ul>
+        <li><a href="#arena-setup">Arena Setup</a></li>
+        <li><a href="#running-a-benchmark">Running a Benchmark</a></li>
+        <li><a href="#analyzing-results">Analyzing Results</a></li>
+      </ul>
+    </li>
+    <li>
       <a href="#supported-models">Supported Models</a>
+      <ul>
+        <li><a href="#model-registry">Model Registry</a></li>
+      </ul>
     </li>
-    </li>
+    <li><a href="#development">Development</a></li>
+    <li><a href="#whats-new">What's New</a></li>
     <li><a href="#license">License</a></li>
     <li><a href="#contact">Contact</a></li>
   </ol>
@@ -36,11 +49,13 @@
 <!-- ABOUT THE PROJECT -->
 ## About The Project
 
-A Poker bot designed for [PokerNow](https://www.pokernow.club) using ChatGPT (or other models! check the Supported Models section below) to make decisions for the user. The bot web scrapes and fetches logs from PokerNow, building a model of the live game: the stakes, the user's hole cards, every player's position and stack size, the current pot size, the current street and shown community cards, and previous actions made by the the bot and other players. 
+A Poker bot designed for [PokerNow](https://www.pokernow.club) using ChatGPT (or other models! check the Supported Models section below) to make decisions for the user. The bot web scrapes and fetches logs from PokerNow, building a model of the live game: the stakes, the user's hole cards, every player's position and stack size, the current pot size, the current street and shown community cards, and previous actions made by the the bot and other players.
 
 This model is used to formulate a query, fed into an LLM model. The output is parsed to reach a decision for the user, which is then executed automatically by the webdriver. The history of queries is maintained across a single hand and passed back into the model so that it can "remember" previous actions, such as who was the preflop aggressor.
 
-During the operation of the bot, a cache is maintained to track the stats of every player in the table (VPIP, PFR). After the session ends, a SQLite database is updated with the players' stats, tracked by the player's name. This data will be retrieved the next time the user plays against that opponent again, building a stronger model of the opponent's tendencies the more the user plays against them. Each player's stats are used in the query, allowing the bot to make personalized exploitative adjustments to its strategy.
+During the operation of the bot, a cache is maintained to track the stats of every player in the table (VPIP, PFR, 3-bet, fold-to-3-bet, aggression frequency). After the session ends, a SQLite database is updated with the players' stats, tracked by the player's name. This data will be retrieved the next time the user plays against that opponent again, building a stronger model of the opponent's tendencies the more the user plays against them. Each player's stats are used in the query, allowing the bot to make personalized exploitative adjustments to its strategy.
+
+The project also ships an **[Arena](#the-arena)** — an offline LLM-vs-LLM poker benchmark that runs on a real rules engine, so you can measure which model actually plays better poker before pointing it at a live table.
 
 ### Why ChatGPT (or other LLMs) over GTO?
 
@@ -62,6 +77,26 @@ As ChatGPT and LLMs/generative models as a whole improve over time, we can and s
 * [Express][Express-url]
 * [Puppeteer][Puppeteer-url]
 * [SQLite][SQLite-url]
+* [PokerKit][PokerKit-url] (Python — the arena's rules engine)
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+### Project Layout
+
+The codebase is split into three parts, and the split is enforced by a checker
+rather than convention alone:
+
+| Layer | Path | What it owns |
+| --- | --- | --- |
+| **core** | `src/core/**` | The environment-agnostic "poker brain": LLM provider abstraction, prompt construction, domain models, decision logic. Knows poker, not *where* the game is played. |
+| **live** | `src/live/**` | Everything PokerNow-specific: the Puppeteer driver, log scraping/parsing, state building, action execution, the bot runner, and the REST API. |
+| **arena** | `src/arena/**` | The LLM-vs-LLM benchmark on an owned engine. Implements the same state-in / action-out seam as live and reuses the core brain verbatim. |
+
+State goes **in** to core; actions come **out**. `core` never imports `live` or
+`arena`, and `arena` never imports `live` — so the same decision engine that
+plays a real PokerNow table also plays the benchmark, with no branching on
+which environment it's in. `npm run check:boundaries` verifies this, and
+`npm test` fails on any violation.
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
@@ -72,7 +107,10 @@ As ChatGPT and LLMs/generative models as a whole improve over time, we can and s
 
 ### Installation
 
-1. Get an OpenAI API Key at [https://platform.openai.com/docs/overview](https://platform.openai.com/docs/overview) and/or a Google AI API Key at [https://aistudio.google.com/apikey](https://aistudio.google.com/apikey)
+1. Get an API key for at least one provider:
+   - OpenAI — [https://platform.openai.com/docs/overview](https://platform.openai.com/docs/overview)
+   - Google AI — [https://aistudio.google.com/apikey](https://aistudio.google.com/apikey)
+   - Anthropic — [https://console.anthropic.com](https://console.anthropic.com)
 2. Clone the repo
    ```sh
    git clone https://github.com/csong2022/pokernow-gpt.git
@@ -85,8 +123,11 @@ As ChatGPT and LLMs/generative models as a whole improve over time, we can and s
    ```
    OPENAI_API_KEY=YOUR_API_KEY
    GOOGLEAI_API_KEY=YOUR_API_KEY
+   CLAUDEAI_API_KEY=YOUR_API_KEY
    ```
+   Only the key for the provider you actually use is required.
 5. (Optional) Adjust bot and webdriver settings in `src/config/bot.config.json` and `src/config/webdriver.config.json`.
+6. (Optional) If you want to run the [Arena](#the-arena), set up the Python engine — see [Arena Setup](#arena-setup).
 
 ### Running the Bot
 
@@ -112,10 +153,18 @@ curl -X POST http://localhost:8080/bot/create \
     "ai_settings": {
       "provider": "OpenAI",
       "model_name": "gpt-5.4-mini",
-      "playstyle": "neutral"
+      "playstyle": "neutral",
+      "reasoning": "medium"
     }
   }'
 ```
+
+| Field | Notes |
+| --- | --- |
+| `provider` | `"OpenAI"`, `"Google"`, or `"Anthropic"`. |
+| `model_name` | The **provider's own API model string** (e.g. `gpt-5.4-mini`, `claude-opus-5`), not an arena registry id. See [Supported Models](#supported-models). |
+| `playstyle` | Steers the system prompt. `"neutral"` is the default. |
+| `reasoning` | Optional: `none` \| `low` \| `medium` \| `high`. Maps to each provider's own thinking knob. Use `none` for models that don't reason. |
 
 The `game_id` is the string at the end of the PokerNow URL: `pokernow.club/games/<game_id>`. On success the response returns a `bot_uuid` — save it to stop or retry the bot later.
 
@@ -148,17 +197,233 @@ curl -X POST http://localhost:8080/bot/stop \
 ```
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
+<!-- THE ARENA -->
+## The Arena
+
+The arena is an offline benchmark that sits LLMs down at the same table and
+measures who actually wins. It runs on **[PokerKit][PokerKit-url]**, a real
+Python rules engine, so no poker rules are reimplemented — and it reuses the
+exact prompt construction and decision engine the live bot uses, so results
+transfer.
+
+Two things make the numbers trustworthy:
+
+- **Duplicate-deck variance reduction.** Each deal is played multiple times with
+  the seat→model assignment rotated, so every model sees the same cards from
+  every position. Card luck cancels out when results are grouped by deal, which
+  is what makes a few hundred hands informative instead of noise.
+- **Statelessness by construction.** Arena agents get no opponent history — the
+  prompt-context port is wired to a no-op, so there is no code path that reads
+  it. That keeps replays identical and makes a model's win rate attributable to
+  the model rather than to in-run adaptation.
+
+### Arena Setup
+
+One-time Python venv setup:
+
+```sh
+py -m venv engine-py/.venv
+engine-py/.venv/Scripts/python.exe -m pip install -r engine-py/requirements.txt   # Windows
+# POSIX: engine-py/.venv/bin/python -m pip install -r engine-py/requirements.txt
+```
+
+The client auto-selects `Scripts/python.exe` vs `bin/python` by platform.
+
+### Running a Benchmark
+
+```sh
+# Stub agents — deterministic legal play, no API cost. Good for a smoke test.
+npx tsx src/arena/index.ts --hands 25 --players 3
+
+# Real models. --llm takes REGISTRY IDS (see Supported Models) and needs the
+# matching provider keys in .env.
+npx tsx src/arena/index.ts --hands 10 --players 2 --llm "gpt-5.4-nano,gemini-3.1-flash-lite-preview"
+
+# Duplicate-deck variance reduction (the mode you want for real comparisons).
+npx tsx src/arena/index.ts --duplicate --deals 50 --players 3 --rotation full \
+  --tag hypothesis-test --notes "why this run exists"
+```
+
+`--rotation` picks how seats are permuted per deal:
+
+| Mode | Replays per deal | Use when |
+| --- | --- | --- |
+| `cyclic` (default) | `P` | Cheap runs and larger tables. Removes seat bias, but for 3+ players the pairwise opponent *ordering* stays confounded. |
+| `full` | `P!` | Ranking experiments. Exact first- and second-order cancellation; only practical at heads-up/3-max (2 and 6 replays). |
+
+The cost of the `cyclic` shortcut is measured, not guessed — `npm run calibrate`
+plays deterministic agents both ways on identical decks and reports the residual.
+
+Each run writes `arena-runs/<runId>/` containing a tracked `manifest.json` (what
+was run: models, format, rotation, git commit, tags) and a gitignored
+`hands.jsonl` (one replayable record per hand).
+
+### Analyzing Results
+
+Analysis is a pure offline pass over the JSONL — the engine doesn't need to be running.
+
+```sh
+npm run analyze arena-runs/<run_id>/hands.jsonl     # a path (file or dir)
+npm run analyze -- --format HU --tag kaggle-validation --write-results   # or a filter
+```
+
+It reports:
+
+- **bb/100, mbb/hand, 95% CI, net bb** per model — plus a variance-reduced table for duplicate runs.
+- **Bradley-Terry ranking** scaled to Elo, fit per format, with a deal-level bootstrap CI. This is a *frequency* statistic (who wins more hands) while bb/100 is a *margin* statistic (who wins more chips) — they can disagree, and that disagreement is informative, which is why both are reported.
+- **Style table** — VPIP / PFR / 3-Bet / Fold-to-3-Bet / AFq per model, derived from the logged actions. How each model plays, not just whether it won.
+- **Decision reliability** — per-model rethink and fallback rates (how often a model's output failed to parse).
+- **Integrity guards** — chip conservation, seat→model consistency, and a hard refusal to pool heads-up results with 3-max.
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
 <!-- SUPPORTED MODELS -->
 ## Supported Models
-providers
----
-"OpenAI", "Google"
 
-models
----
-OpenAI: "gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano"
+**Providers:** `OpenAI`, `Google`, `Anthropic`
 
-Google: "gemini-3.1-pro-preview", "gemini-3-flash-preview", "gemini-3.1-flash-lite-preview"
+The table below is the current registry. The **id** is the stable key used by the
+arena (`--llm`); the live REST API takes the provider's own API model string in
+`model_name` (for most entries these are the same string). **Reasoning** is the
+thinking level the model is configured to use — `none` means the model doesn't reason.
+
+### OpenAI
+
+| Id | Reasoning |
+| --- | --- |
+| `gpt-5.6-sol` | none |
+| `gpt-5.6-terra` | none |
+| `gpt-5.6-luna` | none |
+| `gpt-5.5` | medium |
+| `gpt-5.5-pro` | medium |
+| `gpt-5.4` | medium |
+| `gpt-5.4-mini` | medium |
+| `gpt-5.4-nano` | none |
+| `gpt-5.4-pro` | medium |
+| `gpt-5.3-chat-latest` | none |
+| `gpt-5.2` | medium |
+| `gpt-5.2-pro` | medium |
+| `gpt-5.2-chat-latest` | none |
+| `gpt-5.1` | medium |
+| `gpt-5.1-chat-latest` | none |
+| `o3` | medium |
+
+### Google
+
+| Id | Reasoning |
+| --- | --- |
+| `gemini-3.6-flash` | none |
+| `gemini-3.5-flash` | medium |
+| `gemini-3.5-flash-lite` | none |
+| `gemini-3.1-pro-preview` | medium |
+| `gemini-3.1-flash-lite` | none |
+| `gemini-3.1-flash-lite-preview` | none |
+| `gemini-3-pro-preview` | medium |
+| `gemini-3-flash-preview` | medium |
+
+### Anthropic
+
+| Id | Reasoning |
+| --- | --- |
+| `claude-fable-5` | medium |
+| `claude-opus-5` | medium |
+| `claude-sonnet-5` | medium |
+| `claude-opus-4-8` | medium |
+| `claude-opus-4-7` | medium |
+| `claude-opus-4-6` | medium |
+| `claude-opus-4-5` | none |
+| `claude-sonnet-4-6` | medium |
+| `claude-sonnet-4-5` | none |
+| `claude-haiku-4-5` | none |
+
+### Model Registry
+
+`src/config/models.json` is **script-managed data, not code** — it's read at
+runtime and validated on load, and `scripts/update-models.ts` is its only writer:
+
+```sh
+npm run update-models
+```
+
+That fetches each provider's live model list, keeps the allowlisted families,
+and merges without clobbering — it preserves ids, `addedAt`, costs, and
+`reasoning`; collapses dated snapshots (`gpt-5.4-nano-2026-03-17`) to a family
+id; deprecates rather than deletes models that disappear, so ids in historical
+run logs stay resolvable; and writes deterministically, so a re-run with no
+upstream changes produces a zero diff.
+
+Two fields aren't in any provider list endpoint and are maintained by hand:
+per-1M-token **costs** and the **reasoning** level. New models land with cost `0`
+and reasoning `none` until set; both are preserved across re-runs. Don't hand-edit
+the file for anything else — re-run the script.
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+<!-- DEVELOPMENT -->
+## Development
+
+```sh
+npx tsc --noEmit            # type-check (no build step; tsconfig sets noEmit)
+npm test                    # Mocha unit tests (pretest runs the boundary checker)
+npm run check:boundaries    # non-failing layering report while working
+```
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+<!-- WHAT'S NEW -->
+## What's New
+
+Everything below landed since the last README update.
+
+**Anthropic (Claude) provider.** A third provider alongside OpenAI and Google,
+configured with `CLAUDEAI_API_KEY`.
+
+**Script-managed model registry.** Models moved out of a hardcoded allowlist in
+the service factory (which drifted from what the providers actually served) and
+into `src/config/models.json`, refreshed by `npm run update-models`. Stable ids
+are decoupled from the volatile provider API strings, so a preview→GA rename
+doesn't invalidate historical run logs.
+
+**Reasoning as a first-class setting.** Each model carries a reasoning *level*
+(`none`/`low`/`medium`/`high`) that flows through to each provider's native knob:
+OpenAI `reasoning_effort`, Anthropic adaptive thinking + effort, and a no-op for
+Gemini (which reasons on its own).
+
+**Output regime: reasoning + `Final Answer:`.** Models are asked to reason and
+then end with `Final Answer: <action> <size>`, matching the Kaggle Game Arena
+harness so rankings are comparable and reasoning models can actually reason. The
+parser anchors on the last `Final Answer:` line and ignores the reasoning body,
+so "I considered folding but will raise" resolves to a raise. On a parse failure
+the decision engine re-prompts once before falling back to the safety net, and
+both events are recorded so the analyzer can report per-model reliability.
+
+**The Arena.** An LLM-vs-LLM benchmark on the PokerKit engine, with duplicate-deck
+variance reduction, bb/100 and Bradley-Terry rankings, per-model style stats, a
+run registry with tracked manifests, and full replayable per-decision logs. See
+[The Arena](#the-arena).
+
+**Per-seat playstyles and prompt probes.** The arena CLI takes a `--playstyle`
+per seat, a non-neutral playstyle is encoded into the agent's identity so seats
+stay distinguishable in the logs, and a probe-only system-prompt override allows
+prompt experiments (e.g. tightness probes) without touching the playstyle map.
+Relatedly, the pot-odds cue was removed from the reasoning prompt — it was
+measurably inflating VPIP.
+
+**Three-layer architecture.** The codebase was split into `core` / `live` /
+`arena` with the dependency direction enforced by `scripts/check-boundaries.ts`,
+wired into `pretest` so CI fails on a stray cross-layer import. Core no longer
+touches the browser or the database — it depends on injected ports instead.
+
+**Richer opponent stats.** 3-bet, fold-to-3-bet, and aggression frequency joined
+VPIP/PFR, in both the live exploitative prompt and the arena's offline style table.
+
+**Live bot fixes.**
+- Log polling was collapsed onto the shared game page, dropping the second browser instance.
+- Decision timing is derived from the table's own action clock instead of a fixed delay.
+- Fixed a hang when joining a game that was already in progress.
+- Prompt construction now tolerates unresolved player ids (a rebuy or a new id mid-session no longer throws).
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
 
 <!-- LICENSE -->
 ## License
@@ -181,3 +446,4 @@ Project Link: [https://github.com/csong2022/pokernow-gpt](https://github.com/cso
 [Express-url]: https://expressjs.com/
 [Puppeteer-url]: https://pptr.dev/
 [SQLite-url]: https://www.sqlite.org/
+[PokerKit-url]: https://github.com/uoftcprg/pokerkit

--- a/scripts/update-models.ts
+++ b/scripts/update-models.ts
@@ -4,7 +4,7 @@
  *   npm run update-models
  *
  * For each provider it fetches the live "list models" endpoint, keeps only an
- * allowlisted family (gpt-5.4*, gemini-3*, claude-*-4*), and MERGES into the
+ * allowlisted family (gpt-5.x/o3, gemini-3*, claude-<tier>-<version>), and MERGES into the
  * registry without clobbering: existing ids, addedAt, deprecated, costs, and
  * reasoning are preserved; the (often alias) apiModelString on a matched entry is
  * kept as-is so it stays consistent with the provider SDK / factory.
@@ -95,7 +95,10 @@ async function fetchAnthropic(): Promise<RawModel[]> {
 const PROVIDERS: ProviderSpec[] = [
     { provider: 'OpenAI', keep: (id) => (/^gpt-5\.\d/.test(id) || /^o3(-\d{4}-\d{2}-\d{2})?$/.test(id)) && !/codex/.test(id), fetch: fetchOpenAI },
     { provider: 'Google', keep: (id) => /^gemini-3/.test(id) && !/(image|tts|live|translate|customtools)/.test(id), fetch: fetchGoogle },
-    { provider: 'Anthropic', keep: (id) => /^claude-(opus|sonnet|haiku)-4/.test(id), fetch: fetchAnthropic },
+    // Tier-keyed, version-agnostic: matches the modern `claude-<tier>-<version>`
+    // naming (4.x, 5, and whatever comes next) without a yearly regex bump. The
+    // legacy `claude-3-opus-*` / `claude-2.x` naming doesn't match, by design.
+    { provider: 'Anthropic', keep: (id) => /^claude-(opus|sonnet|haiku|fable)-\d/.test(id), fetch: fetchAnthropic },
 ];
 
 // Fixed key order so JSON.stringify is deterministic regardless of input order.

--- a/src/config/models.json
+++ b/src/config/models.json
@@ -2,6 +2,17 @@
   "_managedBy": "scripts/update-models.ts",
   "models": [
     {
+      "id": "claude-fable-5",
+      "provider": "Anthropic",
+      "apiModelString": "claude-fable-5",
+      "displayName": "Claude Fable 5",
+      "reasoning": "medium",
+      "inputCostPer1M": 10,
+      "outputCostPer1M": 50,
+      "addedAt": "2026-07-31",
+      "deprecated": false
+    },
+    {
       "id": "claude-haiku-4-5",
       "provider": "Anthropic",
       "apiModelString": "claude-haiku-4-5",
@@ -57,6 +68,17 @@
       "deprecated": false
     },
     {
+      "id": "claude-opus-5",
+      "provider": "Anthropic",
+      "apiModelString": "claude-opus-5",
+      "displayName": "Claude Opus 5",
+      "reasoning": "medium",
+      "inputCostPer1M": 5,
+      "outputCostPer1M": 25,
+      "addedAt": "2026-07-31",
+      "deprecated": false
+    },
+    {
       "id": "claude-sonnet-4-5",
       "provider": "Anthropic",
       "apiModelString": "claude-sonnet-4-5-20250929",
@@ -76,6 +98,17 @@
       "inputCostPer1M": 3,
       "outputCostPer1M": 15,
       "addedAt": "2026-06-15",
+      "deprecated": false
+    },
+    {
+      "id": "claude-sonnet-5",
+      "provider": "Anthropic",
+      "apiModelString": "claude-sonnet-5",
+      "displayName": "Claude Sonnet 5",
+      "reasoning": "medium",
+      "inputCostPer1M": 3,
+      "outputCostPer1M": 15,
+      "addedAt": "2026-07-31",
       "deprecated": false
     },
     {
@@ -142,6 +175,28 @@
       "inputCostPer1M": 0,
       "outputCostPer1M": 0,
       "addedAt": "2026-06-15",
+      "deprecated": false
+    },
+    {
+      "id": "gemini-3.5-flash-lite",
+      "provider": "Google",
+      "apiModelString": "gemini-3.5-flash-lite",
+      "displayName": "Gemini 3.5 Flash Lite",
+      "reasoning": "none",
+      "inputCostPer1M": 0,
+      "outputCostPer1M": 0,
+      "addedAt": "2026-07-31",
+      "deprecated": false
+    },
+    {
+      "id": "gemini-3.6-flash",
+      "provider": "Google",
+      "apiModelString": "gemini-3.6-flash",
+      "displayName": "Gemini 3.6 Flash",
+      "reasoning": "none",
+      "inputCostPer1M": 0,
+      "outputCostPer1M": 0,
+      "addedAt": "2026-07-31",
       "deprecated": false
     },
     {
@@ -274,6 +329,39 @@
       "inputCostPer1M": 0,
       "outputCostPer1M": 0,
       "addedAt": "2026-06-15",
+      "deprecated": false
+    },
+    {
+      "id": "gpt-5.6-luna",
+      "provider": "OpenAI",
+      "apiModelString": "gpt-5.6-luna",
+      "displayName": "gpt-5.6-luna",
+      "reasoning": "none",
+      "inputCostPer1M": 0,
+      "outputCostPer1M": 0,
+      "addedAt": "2026-07-31",
+      "deprecated": false
+    },
+    {
+      "id": "gpt-5.6-sol",
+      "provider": "OpenAI",
+      "apiModelString": "gpt-5.6-sol",
+      "displayName": "gpt-5.6-sol",
+      "reasoning": "none",
+      "inputCostPer1M": 0,
+      "outputCostPer1M": 0,
+      "addedAt": "2026-07-31",
+      "deprecated": false
+    },
+    {
+      "id": "gpt-5.6-terra",
+      "provider": "OpenAI",
+      "apiModelString": "gpt-5.6-terra",
+      "displayName": "gpt-5.6-terra",
+      "reasoning": "none",
+      "inputCostPer1M": 0,
+      "outputCostPer1M": 0,
+      "addedAt": "2026-07-31",
       "deprecated": false
     },
     {


### PR DESCRIPTION
## Summary

Refreshes the script-managed model registry and brings the README back in sync with ~40 commits of changes.

## The bug this surfaced

The Anthropic allowlist in `scripts/update-models.ts` was keyed to `claude-*-4*`, so `npm run update-models` was **silently dropping the entire Claude 5 family**. It's now tier-keyed and version-agnostic (`claude-<tier>-<version>`), so a new Claude generation is picked up without a regex bump; the legacy `claude-3-opus-*` naming stays excluded by design.

## Registry changes

8 models added, nothing deprecated, 26 unchanged. A re-run is still a zero diff.

| Provider | Added |
| --- | --- |
| Anthropic | `claude-opus-5`, `claude-sonnet-5`, `claude-fable-5` |
| OpenAI | `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna` |
| Google | `gemini-3.6-flash`, `gemini-3.5-flash-lite` |

Hand-maintained fields set for the Claude 5 entries: `reasoning: medium` (all three drive adaptive thinking + effort, which `claudeai.service.ts` already handles — no code change needed) and real pricing (Fable 5 $10/$50, Opus 5 $5/$25, Sonnet 5 $3/$15 per 1M tokens).

## Follow-ups deliberately left out

- **The new OpenAI/Google entries keep cost `0` / reasoning `none`.** No authoritative pricing or reasoning-capability data for them yet; guessing would corrupt arena cost accounting. They need a manual pass before use in a benchmark.
- Several **pre-existing** entries also carry cost `0` (`claude-opus-4-5/4-6/4-7`, `claude-sonnet-4-5`, all OpenAI/Google), so cost analysis currently undercounts. Out of scope here.

## A latent trap, documented rather than fixed

Registering a Claude 5 model with `reasoning: "none"` would be actively wrong: that path omits `thinking` entirely, but Opus 5 and Fable 5 think by default, and the non-reasoning `max_tokens` of 4096 would then cap thinking + text together — likely truncating before the `Final Answer:` line. Noted in CLAUDE.md; setting them to `medium` avoids it.

## README

Supported Models is now three per-provider tables of the full registry, spelling out the arena-registry-id vs live-REST-provider-string distinction. Added sections for the three-layer layout, the Arena (setup, rotation modes, what the analyzer reports), the registry workflow, and dev commands — plus a "What's New" covering the Anthropic provider, the registry, reasoning levels, the reasoning + `Final Answer:` output regime, the arena, the enforced core/live/arena boundaries, the expanded opponent stats, per-seat playstyles/probes, and the four live-bot fixes.

## Test plan

- [x] `scripts/check-boundaries.ts --strict` — clean
- [x] `tsc --noEmit` — clean
- [x] Mocha suite — 120 passing
- [x] `update-models` re-run — zero diff (idempotent, hand-set fields preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
