### PR TITLE
Fix hand outcomes being dropped by an unparseable stack string

### DIFF
--- a/src/live/pokernow/message-processing.util.ts
+++ b/src/live/pokernow/message-processing.util.ts
@@ -47,6 +47,24 @@ export function getIdToInitialStackFromMsg(msg: string, stakes: number): Map<str
     return res;
 }
 
+// Parse the chip count out of a table stack element's text.
+//
+// PokerNow doesn't render a bare number here. While a pot is being awarded the
+// element also carries the pending win/loss animation ("400 +1200"), and large
+// stacks are grouped ("1,000"). `Number("400 +1200")` is NaN, and NaN has no
+// SQLite representation — it binds as NULL, which is what made the hand-outcome
+// insert fail its NOT NULL constraint on a hand the bot won.
+//
+// Take the FIRST numeric token so the animation suffix is ignored, and strip
+// separators. Returns NaN only when there is genuinely no number to read; callers
+// decide what to do with that rather than silently recording a wrong stack.
+export function parseStackText(text: string | null | undefined): number {
+    if (text === null || text === undefined) return NaN;
+    const match = /-?\d[\d,]*(?:\.\d+)?/.exec(String(text));
+    if (!match) return NaN;
+    return Number(match[0].replace(/,/g, ""));
+}
+
 export function getTableSeatToIdFromMsg(msg: string): Map<number, string>{
     const re = RegExp('\\#(\\d+)\\s\\"[^@]+\\@\\s([^"]*)', 'g');
     const res = new Map<number, string>;

--- a/src/live/pokernow/puppeteer.service.ts
+++ b/src/live/pokernow/puppeteer.service.ts
@@ -1,6 +1,7 @@
 import puppeteer from 'puppeteer';
 
 import { computeTimeout, sleep } from '../../utils/bot-timeout.helper.ts';
+import { parseStackText } from './message-processing.util.ts';
 
 import type { Response } from '../../utils/error-handling.util.ts';
 
@@ -394,9 +395,15 @@ export class PuppeteerService {
         try {
             await this.page.waitForSelector(".you-player > .table-player-infos-ctn > div > .table-player-stack");
             const stack_size_str = await this.page.$eval(".you-player > .table-player-infos-ctn > div > .table-player-stack", (p: any) => p.textContent);
+            // Normalize here so callers get a real number: the raw text carries the
+            // win/loss animation and thousands separators (see parseStackText).
+            const stack_size = parseStackText(stack_size_str);
+            if (!Number.isFinite(stack_size)) {
+                throw new Error(`Unparseable stack text: ${JSON.stringify(stack_size_str)}`);
+            }
             return {
                 code: "success",
-                data: stack_size_str as D,
+                data: stack_size as D,
                 msg: "Successfully retrieved bot's stack size."
             }
         } catch (err) {

--- a/src/live/pokernow/state-builder.ts
+++ b/src/live/pokernow/state-builder.ts
@@ -271,11 +271,15 @@ export class GameStateBuilder {
     private async endHand(): Promise<void> {
         const stack_res = await this.puppeteer.getStackSize();
         logResponse(stack_res, this.debug);
+        // getStackSize now returns a parsed number (it used to hand back the raw DOM
+        // text, which carries the pot-award animation — "400 +1200" — and made both
+        // the conversion and the bust check below silently NaN).
         let ending_stack_BB = 0;
         if (stack_res.code === "success") {
-            this.logger.info("Ending stack size:", stack_res.data);
-            ending_stack_BB = convertToBBs(Number(stack_res.data), this.state.game.getBigBlind());
-            if (Number(stack_res.data) === 0) {
+            const ending_stack = stack_res.data as number;
+            this.logger.info("Ending stack size:", ending_stack);
+            ending_stack_BB = convertToBBs(ending_stack, this.state.game.getBigBlind());
+            if (ending_stack === 0) {
                 this.logger.info(`Bot "${this.state.bot_name}" has busted — stopping after this hand.`);
                 this.state.active = false;
             }
@@ -319,6 +323,17 @@ export class GameStateBuilder {
             position = this.state.table.getPlayerPositionFromId(bot_id);
         } catch {
             // Position not yet known — leave null.
+        }
+
+        // SQLite has no NaN/Infinity: a non-finite number binds as NULL and trips the
+        // NOT NULL constraint, so the row is lost either way. Skip loudly instead of
+        // letting a bad parse upstream turn into a silent gap in the outcome data.
+        if (!Number.isFinite(ending_stack_BB) || !Number.isFinite(starting_stack_BB)) {
+            this.logger.warn(
+                `Skipping hand outcome for hand ${this.state.hand_number}: non-finite stack ` +
+                `(starting=${starting_stack_BB}, ending=${ending_stack_BB}).`,
+            );
+            return;
         }
 
         try {

--- a/test/unit/stack-text.spec.ts
+++ b/test/unit/stack-text.spec.ts
@@ -1,0 +1,45 @@
+/// <reference types="mocha" />
+import { expect } from "chai";
+
+import { parseStackText } from "../../src/live/pokernow/message-processing.util.ts";
+import { convertToBBs } from "../../src/core/poker/value-conversion.util.ts";
+
+describe("parseStackText", () => {
+    it("reads a plain stack", () => {
+        expect(parseStackText("400")).to.equal(400);
+    });
+
+    // Regression: the exact text observed live at hand end, which produced
+    // "NOT NULL constraint failed: HandOutcomes.ending_stack_BB". The element
+    // carries the pending pot award alongside the stack.
+    it("ignores the pot-award animation suffix", () => {
+        expect(parseStackText("400 +1200")).to.equal(400);
+    });
+
+    it("ignores a loss animation suffix", () => {
+        expect(parseStackText("400 -50")).to.equal(400);
+    });
+
+    it("strips thousands separators", () => {
+        expect(parseStackText("1,000")).to.equal(1000);
+        expect(parseStackText("12,345 +6,789")).to.equal(12345);
+    });
+
+    it("handles decimals and surrounding whitespace", () => {
+        expect(parseStackText("  99.5  ")).to.equal(99.5);
+    });
+
+    it("returns NaN when there is no number to read", () => {
+        for (const bad of ["", "   ", "all in", null, undefined]) {
+            expect(parseStackText(bad as any), `input ${JSON.stringify(bad)}`).to.be.NaN;
+        }
+    });
+
+    // The actual failure chain: NaN survives the BB conversion, and better-sqlite3
+    // binds a non-finite number as NULL — hence the NOT NULL violation.
+    it("keeps the BB conversion finite for animated text (the bug)", () => {
+        const big_blind = 20;
+        expect(convertToBBs(Number("400 +1200"), big_blind), "old behavior").to.be.NaN;
+        expect(convertToBBs(parseStackText("400 +1200"), big_blind)).to.equal(20);
+    });
+});


### PR DESCRIPTION
## The bug

`HandOutcomes` was silently never being populated. Found by running the bot against a live table:

```
[7227 claude-sonnet-5] Ending stack size: 400 +1200
[7227 claude-sonnet-5] Failed to record hand outcome: SqliteError: NOT NULL constraint failed: HandOutcomes.ending_stack_BB
```

`getStackSize` returned the stack element's raw `textContent`. PokerNow renders the **pending pot award** in that element while chips are being pushed, so at hand end it reads `"400 +1200"`, not `"400"`. Then:

`Number("400 +1200")` → `NaN` → `NaN / bigBlind` → `NaN` → better-sqlite3 binds a non-finite number as **NULL** → NOT NULL violation.

The insert is wrapped in a `try/catch`, so it failed silently — and **only on hands the bot won**, since that's when the animation is present. `HandOutcomes` is the table the arena's per-model results would draw from.

## Two more bugs, same root cause

- **Bust detection was unreachable.** `Number(stack_res.data) === 0` cannot be true once the text has a suffix, so `state.active = false` never fired and a busted bot would keep playing.
- **The mid-hand path was exposed too.** `readStackSize` cast the DOM *string* `as number` and divided it. Clean text worked by coercion; animated text would have put `My stack: NaN BB` into the prompt and through decision validation.

## The fix

Parse in the adapter rather than at each call site: `parseStackText` takes the first numeric token and strips thousands separators, and `getStackSize` applies it so it returns a real number. That fixes every caller at once and makes the existing `as number` cast honest.

Also skip the outcome row loudly when a stack is non-finite — SQLite has no NaN, so such a row is lost either way, and a warning beats another silent gap.

| Input | Before | After |
|---|---|---|
| `"400"` | 400 | 400 |
| `"400 +1200"` | **NaN** | 400 |
| `"400 -50"` | **NaN** | 400 |
| `"1,000"` | **NaN** | 1000 |
| `""` | NaN | NaN (skipped with a warning) |

## Test plan

- [x] 7 new tests, including a regression test pinning the literal `"400 +1200"` observed at the table
- [x] Full suite: **127 passing** (was 120)
- [x] `tsc --noEmit` clean
- [x] `check:boundaries --strict` clean (via `pretest`)

## Note

Found while verifying the app after the model-registry change; unrelated to that work. One issue from the same live session is **not** addressed here: reasoning models can exceed the table action clock (1 of 8 decisions timed out and defaulted to a safe action with `claude-sonnet-5` at `reasoning: medium` against a 20s clock). That's a config tradeoff rather than a bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
