### PR TITLE
Drop awaits on the synchronous better-sqlite3 layer

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,8 +19,8 @@ app.use('/playerstats', playerstats_router);
 app.use('/bot', bot_router);
 
 async function startServer(port: number) {
-    await db_service.init();
-    await db_service.createTables();
+    db_service.init();
+    db_service.createTables();
     return new Promise<void>((resolve) => {
         app.listen(port, () => {
             console.log(`App listening on http://localhost:${port}`);

--- a/src/live/bot/worker.ts
+++ b/src/live/bot/worker.ts
@@ -28,7 +28,7 @@ async function startBot({ bot_uuid, game_id, name, stack_size, ai_config, bot_co
     await puppeteer_service.init();
 
     const db_service = new DBService("./pokernow-gpt.db");
-    await db_service.init();
+    db_service.init();
     db_service.createTables();
 
     const playerstats_api_service = new PlayerStatsAPIService(db_service);

--- a/src/services/db/db.service.ts
+++ b/src/services/db/db.service.ts
@@ -1,5 +1,10 @@
 import Database from 'better-sqlite3';
 
+// NOTE: better-sqlite3 has no asynchronous API — every method on this class runs
+// to completion synchronously and returns a plain value, not a Promise. Do not
+// `await` them: it reads as I/O that can interleave, when in fact nothing here
+// yields. (Callers that must return a Promise — e.g. implementations of the
+// core PlayerStatsRepository port — can stay `async` without awaiting these.)
 export class DBService {
     private file_name: string;
     private db!: Database.Database;

--- a/src/services/db/handoutcomes.service.ts
+++ b/src/services/db/handoutcomes.service.ts
@@ -22,7 +22,7 @@ export class HandOutcomesAPIService {
     }
 
     async insert(outcome: HandOutcome): Promise<void> {
-        await this.db_service.query(
+        this.db_service.query(
             `INSERT OR REPLACE INTO HandOutcomes
              (hand_id, bot_uuid, bot_name, model_provider, model_name,
               starting_stack_BB, ending_stack_BB, stack_delta_BB,
@@ -45,7 +45,7 @@ export class HandOutcomesAPIService {
     }
 
     async getByModel(model_provider: string, model_name: string): Promise<HandOutcome[]> {
-        const rows = await this.db_service.query(
+        const rows = this.db_service.query(
             `SELECT * FROM HandOutcomes WHERE model_provider = ? AND model_name = ?`,
             [model_provider, model_name],
         );
@@ -53,7 +53,7 @@ export class HandOutcomesAPIService {
     }
 
     async getAll(): Promise<HandOutcome[]> {
-        const rows = await this.db_service.query(`SELECT * FROM HandOutcomes`, []);
+        const rows = this.db_service.query(`SELECT * FROM HandOutcomes`, []);
         return rows as HandOutcome[];
     }
 }

--- a/src/services/db/playerstatsapi.service.ts
+++ b/src/services/db/playerstatsapi.service.ts
@@ -11,7 +11,7 @@ export class PlayerStatsAPIService implements PlayerStatsRepository {
     }
 
     async get(player_name: string): Promise<string> {
-        const rows = await this.db_service.query(
+        const rows = this.db_service.query(
             `SELECT *
              FROM PlayerStats
              WHERE name = ?`,
@@ -21,7 +21,7 @@ export class PlayerStatsAPIService implements PlayerStatsRepository {
     }
     
     async create(player_stats_JSON: any): Promise<void> {
-        await this.db_service.query(
+        this.db_service.query(
             `INSERT INTO PlayerStats
              (name, total_hands, walks, vpip_hands, pfr_hands, three_bet_hands, three_bet_opportunities, faced_three_bet, folded_to_three_bet, total_bets, total_raises, total_calls, total_folds)
              VALUES
@@ -45,7 +45,7 @@ export class PlayerStatsAPIService implements PlayerStatsRepository {
     }
 
     async update(player_name: string, player_stats_JSON: any): Promise<void> {
-        await this.db_service.query(
+        this.db_service.query(
             `UPDATE PlayerStats
              SET
                 total_hands = ?,
@@ -119,7 +119,7 @@ export class PlayerStatsAPIService implements PlayerStatsRepository {
     }
     
     async remove(player_name: string): Promise<void>{
-        await this.db_service.query(
+        this.db_service.query(
             `DELETE FROM PlayerStats
              WHERE name = ?`,
              [player_name]


### PR DESCRIPTION
## The issue

`better-sqlite3` has no asynchronous API. `DBService.query()` returns `Array<any>`, and `init()` / `createTables()` return `void` — yet callers were awaiting them.

`await` on a non-thenable is not a runtime error; it defers a microtask and returns the value unchanged. The cost is legibility: the code reads as if it performs interleavable I/O when nothing here yields, which invites false assumptions about ordering and transaction boundaries.

`updateMany()` in `playerstatsapi.service.ts` already did this correctly (synchronous, no `await`), which is what made the inconsistency visible in the first place.

## How the audit was done

Rather than grepping for `await`, this used the **TypeScript type checker** to resolve each `await` operand's actual type, and also checked the more dangerous inverse — a Promise-returning call whose result is discarded (a real race risk).

**Result: 10 misused awaits, all the same root cause. 0 floating promises.**

| File | Fixed |
|---|---|
| `services/db/playerstatsapi.service.ts` | 4 — `get`, `create`, `update`, `remove` |
| `services/db/handoutcomes.service.ts` | 3 — `insert`, `getByModel`, `getAll` |
| `index.ts` | 2 — `init`, `createTables` |
| `live/bot/worker.ts` | 1 — `init` |

The audit re-runs clean (0 / 0) after this change.

## What is deliberately unchanged

The service methods keep their `Promise` return types. `PlayerStatsRepository` is a **core-owned port** that declares `get`/`create` as async on purpose — the arena's `InMemoryPlayerStatsRepository` implements the same port, and a future backend (network- or process-backed) could be genuinely asynchronous. Collapsing the port to synchronous would leak "the current storage engine happens to be synchronous" into `core` and force a much wider refactor across `Table` and the arena.

So the methods still return promises honestly; they simply no longer pretend the synchronous `query()` is awaitable. A note on `DBService` documents the synchronous contract so the awaits don't creep back.

## Test plan

- [x] Type-checker audit re-run: `await-non-thenable` 0, `floating-promise` 0
- [x] `tsc --noEmit` clean
- [x] Full suite: 127 passing
- [x] `check:boundaries --strict` clean (via `pretest`)

No behavior change is intended: removing an `await` from a non-thenable only removes a microtask tick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
