### PR TITLE
Move BotAction into core/poker; make the fallbacks engine-private

### DIFF
--- a/src/arena/agent.ts
+++ b/src/arena/agent.ts
@@ -1,6 +1,7 @@
 import { Game } from '../core/game/game.model.ts';
 import { AIConfig } from '../core/ai/ai-config.interface.ts';
-import { AIService, BotAction } from '../core/ai/ai-client.interface.ts';
+import { AIService } from '../core/ai/ai-client.interface.ts';
+import { BotAction } from '../core/poker/bot-action.ts';
 import { AIServiceFactory } from '../core/ai/ai-service-factory.helper.ts';
 import { ActionAvailability } from '../core/poker/action-availability.interface.ts';
 import { DecisionEngine, DecisionEvent, DecisionTrace } from '../core/poker/decision-engine.ts';

--- a/src/core/ai/ai-client.interface.ts
+++ b/src/core/ai/ai-client.interface.ts
@@ -1,4 +1,5 @@
 import { ReasoningLevel } from "./ai-config.interface.ts";
+import { BotAction } from "../poker/bot-action.ts";
 
 export abstract class AIService {
     private api_key: string;
@@ -73,17 +74,3 @@ export abstract class AIService {
     }
 }
 
-export interface BotAction {
-    action_str: string,
-    bet_size_in_BBs: number
-}
-
-export const defaultCheckAction = {
-    action_str: "check",
-    bet_size_in_BBs: 0
-}
-
-export const defaultFoldAction = {
-    action_str: "fold",
-    bet_size_in_BBs: 0
-}

--- a/src/core/ai/ai-query.helper.ts
+++ b/src/core/ai/ai-query.helper.ts
@@ -1,4 +1,4 @@
-import { BotAction } from "./ai-client.interface.ts";
+import { BotAction } from "../poker/bot-action.ts";
 
 export const playstyleToPrompt: Map<string, string> = new Map<string, string>([
     ["pro", "You are a pro poker player who plays strong ranges preflop and plays aggressively postflop."],

--- a/src/core/ai/claudeai.service.ts
+++ b/src/core/ai/claudeai.service.ts
@@ -1,5 +1,6 @@
 import Anthropic from "@anthropic-ai/sdk";
-import { AIService, BotAction } from "./ai-client.interface.ts";
+import { AIService } from "./ai-client.interface.ts";
+import { BotAction } from "../poker/bot-action.ts";
 import { getPromptFromPlaystyle, parseResponse } from "./ai-query.helper.ts";
 import { withTimeout } from "../../utils/bot-timeout.helper.ts";
 

--- a/src/core/ai/googleai.service.ts
+++ b/src/core/ai/googleai.service.ts
@@ -1,5 +1,6 @@
 import { ChatSession, GenerativeModel, GoogleGenerativeAI, HarmBlockThreshold, HarmCategory } from "@google/generative-ai";
-import { AIService, BotAction } from "./ai-client.interface.ts";
+import { AIService } from "./ai-client.interface.ts";
+import { BotAction } from "../poker/bot-action.ts";
 import { getPromptFromPlaystyle, parseResponse } from "./ai-query.helper.ts";
 import { withTimeout } from "../../utils/bot-timeout.helper.ts";
 

--- a/src/core/ai/openai.service.ts
+++ b/src/core/ai/openai.service.ts
@@ -1,6 +1,7 @@
 import OpenAI from "openai";
 import { ChatCompletionCreateParamsNonStreaming, ChatCompletionMessageParam } from "openai/resources/chat/completions.mjs";
-import { AIService, BotAction } from "./ai-client.interface.ts";
+import { AIService } from "./ai-client.interface.ts";
+import { BotAction } from "../poker/bot-action.ts";
 import { getPromptFromPlaystyle, parseResponse} from "./ai-query.helper.ts";
 import { withTimeout } from "../../utils/bot-timeout.helper.ts";
 

--- a/src/core/poker/bot-action.ts
+++ b/src/core/poker/bot-action.ts
@@ -1,0 +1,14 @@
+// The domain's representation of a decision at the table: what to do, and for
+// sizing actions how much — in BIG BLINDS, as the TOTAL bet for the street.
+//
+// This lives in core/poker rather than core/ai because it is a poker concept,
+// not an AI-client one. It began life next to the AIService port (it is query()'s
+// return type), but its consumers reach well past that port: the live
+// action-executor performs one at the table and the arena agent maps one onto
+// the engine's legal actions, neither of which cares that a model produced it.
+// Same reasoning that put the Action enum here — shared vocabulary belongs in the
+// poker layer so live and arena don't import it through the AI abstraction.
+export interface BotAction {
+    action_str: string,
+    bet_size_in_BBs: number
+}

--- a/src/core/poker/decision-engine.ts
+++ b/src/core/poker/decision-engine.ts
@@ -16,7 +16,8 @@ export interface DecisionTrace {
     events: DecisionEvent[];
 }
 
-import { AIService, BotAction, defaultCheckAction, defaultFoldAction } from '../ai/ai-client.interface.ts';
+import { AIService } from '../ai/ai-client.interface.ts';
+import { BotAction } from './bot-action.ts';
 import { ActionAvailability } from './action-availability.interface.ts';
 import type { HandContextBuilder } from './hand-context-builder.interface.ts';
 
@@ -24,6 +25,18 @@ import { sleep, TimeoutError } from '../../utils/bot-timeout.helper.ts';
 import { Logger } from '../../utils/logger.util.ts';
 
 import { HandState } from '../game/hand-state.ts';
+
+// Safety net for when the model can't produce a legal action: check if that's
+// legal here, otherwise fold. This is poker policy, not an AI-client concern, so
+// it lives with the engine that applies it (its only consumer) rather than on the
+// provider port.
+//
+// Typed so a typo in action_str is a compile error rather than a silent fold at
+// the table, and frozen because fallback() hands these objects themselves to
+// callers in live/arena — one stray mutation would corrupt every later fallback
+// in the process.
+const defaultCheckAction: BotAction = Object.freeze({ action_str: "check", bet_size_in_BBs: 0 });
+const defaultFoldAction: BotAction = Object.freeze({ action_str: "fold", bet_size_in_BBs: 0 });
 
 export class DecisionEngine {
     constructor(

--- a/src/live/pokernow/action-executor.ts
+++ b/src/live/pokernow/action-executor.ts
@@ -1,6 +1,6 @@
 import { convertToBBs, convertToValue } from '../../core/poker/value-conversion.util.ts';
 
-import { BotAction } from '../../core/ai/ai-client.interface.ts';
+import { BotAction } from '../../core/poker/bot-action.ts';
 import { PuppeteerService } from './puppeteer.service.ts';
 
 import { DebugMode, logResponse } from '../../utils/error-handling.util.ts';


### PR DESCRIPTION
## Why

`BotAction` and two fallback constants lived in `core/ai/ai-client.interface.ts`. `BotAction` ended up there for a defensible reason — it's the return type of `AIService.query()`, so the DTO sat next to its port. But it outgrew that placement, and the constants never belonged there at all.

**`BotAction` is a poker concept, not an AI-client one.** Its consumers reach well past the AI port: the live `action-executor` performs one at the table, and the arena `agent` maps one onto the engine's legal actions. Neither cares that a model produced it. The symptom was `live/` importing from `core/ai/` just to name a decision:

```ts
// src/live/pokernow/action-executor.ts — before
import { BotAction } from '../../core/ai/ai-client.interface.ts';
```

`core/poker/` already holds exactly this kind of shared vocabulary — the `Action` enum was lifted there so core and the live parsers could share it without a bad dependency. `BotAction` has the same shape of problem and gets the same answer: it now lives in `core/poker/bot-action.ts`, and live/arena import a poker type from the poker layer.

**The two constants are poker policy.** `defaultCheckAction` / `defaultFoldAction` encode "when the model fails, check if legal, otherwise fold." They had exactly one consumer — `DecisionEngine.fallback()` — yet were exported from the provider port, so the AI abstraction was publishing a strategy decision. They're now module-private to `decision-engine.ts`.

## Two latent bugs closed along the way

**They were untyped.** `export const defaultCheckAction = {...}` had no annotation, so it was inferred as `{action_str: string; bet_size_in_BBs: number}` — structurally compatible by luck. A typo like `"chekc"` compiled fine and only surfaced at runtime, where `isValidBotAction` rejects it and the bot folds a hand it could have checked. Now annotated `: BotAction`, so that's a compile error.

**They were shared mutable singletons.** `fallback()` returns the object itself, not a copy:

```ts
return (await this.isValidBotAction(defaultCheckAction)) ? defaultCheckAction : defaultFoldAction;
```

That identity escapes into live and arena code. Nothing mutates them today (checked `action-executor` and `decision-engine` — both only read), but a single future `bot_action.bet_size_in_BBs = x` would corrupt the constant for every subsequent fallback in the process. Now `Object.freeze`d, so such a write throws loudly under ESM strict mode instead of silently poisoning later decisions.

## Notes

No re-export shim was left behind on the old path — that would preserve exactly the ambiguity this removes. All 8 import sites were updated outright.

`ai-client.interface.ts` still imports `BotAction`; that's correct and is the point of the type — it remains `query()`'s return type. What changed is the direction: the AI port now depends on the poker vocabulary rather than owning it.

Pure move plus typing/freezing — no behavior change intended.

## Test plan

- [x] `check:boundaries --strict` clean (all three layers)
- [x] `tsc --noEmit` clean
- [x] Full suite: 127 passing
- [x] Verified no remaining import of `BotAction` or the constants through the AI port

🤖 Generated with [Claude Code](https://claude.com/claude-code)
